### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that integrates FindMine's powerful product styling and outfitting recommendations with Claude and other MCP-compatible applications.
 
+<a href="https://glama.ai/mcp/servers/@findmine/findmine-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@findmine/findmine-mcp/badge" alt="FindMine Shopping Stylist MCP server" />
+</a>
+
 ## Overview
 
 This MCP server connects to FindMine's styling API and exposes its functionality to Large Language Models through the Model Context Protocol. It allows users to:


### PR DESCRIPTION
This PR adds a badge for the [FindMine Shopping Stylist](https://glama.ai/mcp/servers/@findmine/findmine-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@findmine/findmine-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@findmine/findmine-mcp/badge" alt="FindMine Shopping Stylist MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.